### PR TITLE
商品名検索機能とジャンル絞り込み機能の追加

### DIFF
--- a/app/assets/javascripts/admin/searches.coffee
+++ b/app/assets/javascripts/admin/searches.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/public/searches.coffee
+++ b/app/assets/javascripts/public/searches.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/admin/searches.scss
+++ b/app/assets/stylesheets/admin/searches.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the admin/searches controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/public/searches.scss
+++ b/app/assets/stylesheets/public/searches.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the public/searches controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -1,7 +1,7 @@
 class Admin::ItemsController < ApplicationController
   before_action:authenticate_admin!
   layout "admin"
-  
+
   def index
     @items = Item.page(params[:page]).per(10)
   end

--- a/app/controllers/admin/searches_controller.rb
+++ b/app/controllers/admin/searches_controller.rb
@@ -1,0 +1,6 @@
+class Admin::SearchesController < ApplicationController
+  def search
+    @items = Item.search(params[:keyword]).page(params[:page]).per(10)
+    @keyword = params[:keyword]
+  end
+end

--- a/app/controllers/admin/searches_controller.rb
+++ b/app/controllers/admin/searches_controller.rb
@@ -1,4 +1,7 @@
 class Admin::SearchesController < ApplicationController
+  before_action:authenticate_admin!
+  layout "admin"
+  
   def search
     @items = Item.search(params[:keyword]).page(params[:page]).per(10)
     @keyword = params[:keyword]

--- a/app/controllers/public/homes_controller.rb
+++ b/app/controllers/public/homes_controller.rb
@@ -1,6 +1,7 @@
 class Public::HomesController < ApplicationController
   def top
     @items = Item.order('id DESC').limit(4)
+    @genres = Genre.all
   end
 
   def about

--- a/app/controllers/public/items_controller.rb
+++ b/app/controllers/public/items_controller.rb
@@ -1,9 +1,11 @@
 class Public::ItemsController < ApplicationController
   def index
     @items = Item.page(params[:page]).per(8)
+    @genres = Genre.all
   end
 
   def show
     @item = Item.find(params[:id])
+    @genres = Genre.all
   end
 end

--- a/app/controllers/public/searches_controller.rb
+++ b/app/controllers/public/searches_controller.rb
@@ -1,11 +1,13 @@
 class Public::SearchesController < ApplicationController
   def genre_search
+    @genres = Genre.all
     @value = params["search"]["value"]
     @how = params["search"]["how"]
     @datas = search_for(@how, @value)
   end
 
   def item_search
+    @genres = Genre.all
     @items = Item.search(params[:keyword]).page(params[:page]).per(8)
     @keyword = params[:keyword]
   end

--- a/app/controllers/public/searches_controller.rb
+++ b/app/controllers/public/searches_controller.rb
@@ -1,0 +1,26 @@
+class Public::SearchesController < ApplicationController
+  def genre_search
+    @value = params["search"]["value"]
+    @how = params["search"]["how"]
+    @datas = search_for(@how, @value)
+  end
+
+  def item_search
+    @items = Item.search(params[:keyword]).page(params[:page]).per(8)
+    @keyword = params[:keyword]
+  end
+
+  private
+
+  def match(value)
+    @genre = Genre.find_by(name: value)
+    Item.where(genre_id: @genre)
+  end
+
+  def search_for(how, value)
+    case how
+    when 'match'
+      match(value)
+    end
+  end
+end

--- a/app/helpers/admin/searches_helper.rb
+++ b/app/helpers/admin/searches_helper.rb
@@ -1,0 +1,2 @@
+module Admin::SearchesHelper
+end

--- a/app/helpers/public/searches_helper.rb
+++ b/app/helpers/public/searches_helper.rb
@@ -1,0 +1,2 @@
+module Public::SearchesHelper
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -11,4 +11,12 @@ class Item < ApplicationRecord
   def add_tax_included_price
     (self.tax_encluded_price * 1.08).round
   end
+
+  def self.search(search)
+    if search != ""
+      Item.where('name LIKE ?', "%#{search}%")
+    else
+      Item.all
+    end
+  end
 end

--- a/app/views/admin/items/index.html.erb
+++ b/app/views/admin/items/index.html.erb
@@ -1,5 +1,3 @@
-<%= render "admin/searches/form" %>
-
 <h3>商品一覧</h3>
 
 <%= link_to "新規登録", new_admin_item_path %>

--- a/app/views/admin/searches/_form.html.erb
+++ b/app/views/admin/searches/_form.html.erb
@@ -1,0 +1,9 @@
+<%= form_with url: admin_search_path, method: :get, local: true do |f| %>
+  <div class="form-group">
+    <%= f.text_field :keyword, placeholder: "商品名で検索" %>
+  </div>
+
+  <div class="form-group">
+    <%= f.submit "検索" %>
+  </div>
+<% end %>

--- a/app/views/admin/searches/search.html.erb
+++ b/app/views/admin/searches/search.html.erb
@@ -1,4 +1,4 @@
-<h3><%= @keyword %>一覧</h3>
+<h3>"<%= @keyword %>"の検索結果</h3>
 
 <table class="table">
   <thead>

--- a/app/views/admin/searches/search.html.erb
+++ b/app/views/admin/searches/search.html.erb
@@ -1,8 +1,4 @@
-<%= render "admin/searches/form" %>
-
-<h3>商品一覧</h3>
-
-<%= link_to "新規登録", new_admin_item_path %>
+<h3><%= @keyword %>一覧</h3>
 
 <table class="table">
   <thead>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -78,19 +78,23 @@
 
               <% end %>
             </ul>
-            
+
+            <% if admin_signed_in? %>
+              <%= render "admin/searches/form" %>
+            <% end %>
+
           </div>
         </div>
       </nav>
-      
+
     </header>
-    
+
     <main>
       <%= yield %>
     </main>
-    
+
     <footer>
     </footer>
-    
+
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -74,18 +74,20 @@
 
               <% end %>
             </ul>
-            
+
+            <%= render "public/searches/form" %>
+
           </div>
         </div>
       </nav>
     </header>
-    
+
     <main>
       <%= yield %>
     <main>
-      
+
     <footer>
-    </footer>  
-    
+    </footer>
+
   </body>
 </html>

--- a/app/views/public/homes/top.html.erb
+++ b/app/views/public/homes/top.html.erb
@@ -1,3 +1,5 @@
+<%= render "public/searches/genre_sidebar", genres: @genres %>
+
 <p>ようこそ、ながのCAKEへ！<br/>
 このサイトは、ケーキ販売のECサイトになります。<br/>
 会員でない方も商品の閲覧はできますが、<br/>

--- a/app/views/public/items/index.html.erb
+++ b/app/views/public/items/index.html.erb
@@ -1,4 +1,3 @@
-<%= render "public/searches/form" %>
 
 <%= render "public/searches/genre_sidebar", genres: @genres %>
 

--- a/app/views/public/items/show.html.erb
+++ b/app/views/public/items/show.html.erb
@@ -1,3 +1,5 @@
+<%= render "public/searches/genre_sidebar", genres: @genres %>
+
 <div><%= attachment_image_tag @item, :image, :fill, 300, 250 %></div>
 <div><%= @item.name %></div>
 <div><%= @item.description%></div>

--- a/app/views/public/searches/_form.html.erb
+++ b/app/views/public/searches/_form.html.erb
@@ -1,0 +1,9 @@
+<%= form_with url: item_search_path, method: :get, local: true do |f| %>
+  <div class="form-group">
+    <%= f.text_field :keyword, placeholder: "商品名で検索" %>
+  </div>
+
+  <div class="form-group">
+    <%= f.submit "検索" %>
+  </div>
+<% end %>

--- a/app/views/public/searches/_genre_sidebar.html.erb
+++ b/app/views/public/searches/_genre_sidebar.html.erb
@@ -7,7 +7,7 @@
   <tbody>
     <% genres.each do |genre| %>
       <tr>
-        <td><%= link_to genre.name, genre_search_path('search[value]': genre.name, 'search[how]': "match") %></td>
+        <td><%= link_to genre.name, genre_search_path('search[value]': genre.name, 'search[how]': "match"), class: "text-dark" %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/public/searches/_genre_sidebar.html.erb
+++ b/app/views/public/searches/_genre_sidebar.html.erb
@@ -1,0 +1,14 @@
+<table class="table">
+  <thead>
+    <tr>
+      <th>ジャンル検索</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% genres.each do |genre| %>
+      <tr>
+        <td><%= link_to genre.name, genre_search_path('search[value]': genre.name, 'search[how]': "match") %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/public/searches/genre_search.html.erb
+++ b/app/views/public/searches/genre_search.html.erb
@@ -1,10 +1,12 @@
+<%= render "public/searches/genre_sidebar", genres: @genres %>
+
 <h3><%= @value %>一覧</h3>
 
 <% if @datas.empty? %>
   <div>該当商品はありません</div>
 <% else %>
+  <div>（全<%= @datas.count %>件）</div>
   <% @datas.each do |data| %>
-    <div>（全<%= @datas.count %>件）</div>
     <div>
       <%= link_to item_path(data.id) do %>
         <%= attachment_image_tag data, :image, :fill, 200, 150 %>

--- a/app/views/public/searches/genre_search.html.erb
+++ b/app/views/public/searches/genre_search.html.erb
@@ -1,0 +1,17 @@
+<h3><%= @value %>一覧</h3>
+
+<% if @datas.empty? %>
+  <div>該当商品はありません</div>
+<% else %>
+  <% @datas.each do |data| %>
+    <div>（全<%= @datas.count %>件）</div>
+    <div>
+      <%= link_to item_path(data.id) do %>
+        <%= attachment_image_tag data, :image, :fill, 200, 150 %>
+      <% end %>
+    </div>
+    <div><%= data.name %></div>
+    <div>¥<%= data.add_tax_included_price.to_s(:delimited) %></div>
+  <% end %>
+<% end %>
+

--- a/app/views/public/searches/item_search.html.erb
+++ b/app/views/public/searches/item_search.html.erb
@@ -1,4 +1,6 @@
-<h3><%= @keyword %>一覧</h3>
+<%= render "public/searches/genre_sidebar", genres: @genres %>
+
+<h3>"<%= @keyword %>"の検索結果</h3>
 <div>（全<%= @items.total_count %>件）</div>
 
 <% @items.each do |item| %>

--- a/app/views/public/searches/item_search.html.erb
+++ b/app/views/public/searches/item_search.html.erb
@@ -1,8 +1,4 @@
-<%= render "public/searches/form" %>
-
-<%= render "public/searches/genre_sidebar", genres: @genres %>
-
-<h3>商品一覧</h3>
+<h3><%= @keyword %>一覧</h3>
 <div>（全<%= @items.total_count %>件）</div>
 
 <% @items.each do |item| %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
     resources :customers, only:[:index, :show, :edit, :update]
     resources :orders, only:[:show, :update]
     resources :order_items, only:[:update]
+    get '/search', to: "searches#search"
   end
 
   devise_for :customer, skip:[:passwords], controllers:{
@@ -32,6 +33,10 @@ Rails.application.routes.draw do
     get "/orders/thankyou", to: "orders#thankyou"
     get "/orders/check", to: "orders#check"
     resources :shipping_addresses, except:[:new, :show]
+    # ジャンル検索用ルーティング
+    get '/genre_search', to: "searches#genre_search"
+    # 商品名検索用ルーティング
+    get '/item_search', to: "searches#item_search"
   end
 
 end

--- a/spec/helpers/admin/searches_helper_spec.rb
+++ b/spec/helpers/admin/searches_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the Admin::SearchesHelper. For example:
+#
+# describe Admin::SearchesHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe Admin::SearchesHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/helpers/public/searches_helper_spec.rb
+++ b/spec/helpers/public/searches_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the Public::SearchesHelper. For example:
+#
+# describe Public::SearchesHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe Public::SearchesHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/admin/searches_spec.rb
+++ b/spec/requests/admin/searches_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe "Admin::Searches", type: :request do
+  describe "GET /search" do
+    it "returns http success" do
+      get "/admin/searches/search"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/requests/public/searches_spec.rb
+++ b/spec/requests/public/searches_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe "Public::Searches", type: :request do
+  describe "GET /search" do
+    it "returns http success" do
+      get "/public/searches/search"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/views/admin/searches/search.html.erb_spec.rb
+++ b/spec/views/admin/searches/search.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "searches/search.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/public/searches/search.html.erb_spec.rb
+++ b/spec/views/public/searches/search.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "searches/search.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 商品名検索機能・ジャンル絞り込み機能
* adminとpublicにsearches_controller.rb追加
  * admin側　商品名検索のための記述
  * public側　商品名検索とジャンル絞り込みのための記述

* item.rb
  * 商品名で部分一致検索するための記述追加
* routes.rb
  * adminとpublicにsearch用のルーティング追加
* view
  * admin側　
    * 商品名検索結果画面、admin用の検索フォーム(部分テンプレート)
  * public側　
    * 商品名検索結果画面、ジャンル名絞り込み結果画面、ジャンル絞り込み用サイドバー(部分テンプレート)、public用の検索フォーム(部分テンプレート)
  * layouts/admin.html.erbにadmin用検索フォーム追加
  * layouts/application.html.erbにpublic用検索フォーム追加
  * homes/top、public/items/index.html.erb,show.html.erbにジャンル絞り込み用サイドバー追加
* homes_controller.rb,public/items_controller.rbにgenreテーブルの中身を取得する記述追加